### PR TITLE
OpenMDAO v1.x+ no longer supports IAssembly

### DIFF
--- a/src/commonse/utilities.py
+++ b/src/commonse/utilities.py
@@ -9,7 +9,6 @@ Copyright (c) NREL. All rights reserved.
 
 import numpy as np
 from scipy.linalg import solve_banded
-from openmdao.main.interfaces import IAssembly
 
 
 def cosd(value):
@@ -376,85 +375,85 @@ class CubicSplineSegment(object):
 
 
 
-def print_vars(comp, list_type='inputs', prefix='', astable=False):
-
-    comp_reserved = ['driver']
-    reserved = ['missing_deriv_policy', 'force_execute', 'directory', 'force_fd', 'printvars', 'exec_count']
-
-    # recursively search for subassemblies
-    if IAssembly.providedBy(comp):  # outer needs to be an assembly
-        subcomp = comp.list_components()
-
-        for subc_name in subcomp:
-            if subc_name in comp_reserved:
-                continue
-
-            subc = getattr(comp, subc_name)
-            if IAssembly.providedBy(subc):  # inner must be an subassembly
-                if prefix is not None:
-                    newprefix = prefix + '.' + subc_name
-                else:
-                    newprefix = subc_name
-                print_vars(subc, list_type, newprefix, astable)
-                continue
-
-
-    if list_type == 'inputs':
-        thelist = comp.list_inputs(connected=False)
-    elif list_type == 'outputs':
-        thelist = comp.list_outputs(connected=False)
-    elif list_type == 'vars':
-        thelist = comp.list_vars()
-
-    for name in thelist:
-
-        if name in reserved:
-            continue
-
-        trait = comp.get_trait(name)
-        thetype = trait.trait_type.__str__().split()[0].split('.')[-1]
-
-        if thetype == 'VarTree':
-            vartree = getattr(comp, name)
-            if prefix is not None:
-                newprefix = prefix + '.' + name
-            else:
-                newprefix = name
-            print_vars(vartree, 'vars', newprefix, astable)
-            continue
-
-        units = trait.units
-        desc = trait.desc
-        default = trait.default
-        # print trait.category
-
-        if units is None:
-            description = '(' + thetype + ')'
-        else:
-            description = '(' + thetype + ', ' + units + ')'
-
-        if desc is not None:
-            description += ': ' + desc
-
-
-        if prefix is not '':
-            name = prefix + '.' + name
-
-        if not astable:
-            name = name + ' = ' + str(default)
-            print name + '  # ' + description
-
-        else:
-
-            if not units:
-                units = ''
-            if not desc:
-                desc = ''
-            strdefault = str(default)
-            if strdefault == '<undefined>':
-                strdefault = ''
-
-            print '{0:15}\t{1:10}\t{2:15}\t{3:10}\t{4}'.format(name, thetype, strdefault, units, desc)
+# def print_vars(comp, list_type='inputs', prefix='', astable=False):
+#
+#     comp_reserved = ['driver']
+#     reserved = ['missing_deriv_policy', 'force_execute', 'directory', 'force_fd', 'printvars', 'exec_count']
+#
+#     # recursively search for subassemblies
+#     if IAssembly.providedBy(comp):  # outer needs to be an assembly
+#         subcomp = comp.list_components()
+#
+#         for subc_name in subcomp:
+#             if subc_name in comp_reserved:
+#                 continue
+#
+#             subc = getattr(comp, subc_name)
+#             if IAssembly.providedBy(subc):  # inner must be an subassembly
+#                 if prefix is not None:
+#                     newprefix = prefix + '.' + subc_name
+#                 else:
+#                     newprefix = subc_name
+#                 print_vars(subc, list_type, newprefix, astable)
+#                 continue
+#
+#
+#     if list_type == 'inputs':
+#         thelist = comp.list_inputs(connected=False)
+#     elif list_type == 'outputs':
+#         thelist = comp.list_outputs(connected=False)
+#     elif list_type == 'vars':
+#         thelist = comp.list_vars()
+#
+#     for name in thelist:
+#
+#         if name in reserved:
+#             continue
+#
+#         trait = comp.get_trait(name)
+#         thetype = trait.trait_type.__str__().split()[0].split('.')[-1]
+#
+#         if thetype == 'VarTree':
+#             vartree = getattr(comp, name)
+#             if prefix is not None:
+#                 newprefix = prefix + '.' + name
+#             else:
+#                 newprefix = name
+#             print_vars(vartree, 'vars', newprefix, astable)
+#             continue
+#
+#         units = trait.units
+#         desc = trait.desc
+#         default = trait.default
+#         # print trait.category
+#
+#         if units is None:
+#             description = '(' + thetype + ')'
+#         else:
+#             description = '(' + thetype + ', ' + units + ')'
+#
+#         if desc is not None:
+#             description += ': ' + desc
+#
+#
+#         if prefix is not '':
+#             name = prefix + '.' + name
+#
+#         if not astable:
+#             name = name + ' = ' + str(default)
+#             print name + '  # ' + description
+#
+#         else:
+#
+#             if not units:
+#                 units = ''
+#             if not desc:
+#                 desc = ''
+#             strdefault = str(default)
+#             if strdefault == '<undefined>':
+#                 strdefault = ''
+#
+#             print '{0:15}\t{1:10}\t{2:15}\t{3:10}\t{4}'.format(name, thetype, strdefault, units, desc)
 
 
 


### PR DESCRIPTION
RotorSE uses some functions from utilities.py but it has an import
error due to IAssembly not being supported in OpenMDAO v1.x+. I
commented out the only function that used IAssembly to prevent
accidental use.